### PR TITLE
Avoid infinite loop when tsconfig.json is not exists

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -10,9 +10,15 @@ export function findAndReadConfig (
   const configFileName = 'tsconfig.json'
 
   function loop (dir: string): ts.ParsedCommandLine | undefined {
+    const parentPath = path.dirname(dir)
+    // It is root directory if parent and current dirname are the same
+    if (dir === parentPath) {
+      return undefined
+    }
+
     const configPath = path.join(dir, configFileName)
     if (!_exists(configPath)) {
-      return loop(dir.slice(0, -1))
+      return loop(parentPath)
     }
 
     const result = ts.readConfigFile(configPath, _parseConfigHost.readFile)

--- a/test/specs/config.ts
+++ b/test/specs/config.ts
@@ -66,6 +66,11 @@ describe('tsconfig detection', () => {
     const options = data!.options
     assert(options.target === ScriptTarget.ES2015)
   })
+
+  it('returns undefined if config is not found', () => {
+    const data = findAndReadConfig('/path/to/src', host, exists)
+    assert(data === undefined)
+  })
 })
 
 function readFile (fileName: string): string {


### PR DESCRIPTION
If there is no `tsconfig.json` in all ancestor directories, infinite loop will be occurred. This PR fixes the problem.