### PR TITLE
unit test for generation fails if sfc has additional type/interface/class declarations

### DIFF
--- a/test/fixtures/ts-class-with-additional-type.vue
+++ b/test/fixtures/ts-class-with-additional-type.vue
@@ -6,7 +6,7 @@
 import Vue = require('vue')
 import Component from 'vue-class-component'
 
-type Foo = string;
+export type Foo = string;
 
 @Component
 export default class TsClass extends Vue {

--- a/test/fixtures/ts-class-with-additional-type.vue
+++ b/test/fixtures/ts-class-with-additional-type.vue
@@ -1,0 +1,21 @@
+<template>
+  <div>{{ foo }}</div>
+</template>
+
+<script lang="ts">
+import Vue = require('vue')
+import Component from 'vue-class-component'
+
+type Foo = string;
+
+@Component
+export default class TsClass extends Vue {
+  foo: Foo = 'Hello'
+}
+</script>
+
+<style>
+div {
+  color: red;
+}
+</style>

--- a/test/specs/generate.ts
+++ b/test/specs/generate.ts
@@ -33,6 +33,12 @@ describe('generate', () => {
     })
   })
 
+  it('should emit d.ts for class component with additional type in sfc', () => {
+    return gen(fixtures('ts-class.vue'), compilerOptions).then(() => {
+      test(fixtures('ts-class-with-additional-type.vue.d.ts'), expects('ts-class.vue.d.ts'))
+    })
+  })
+
   it('should emit d.ts for component options in sfc', () => {
     return gen(fixtures('ts-object.vue'), {}).then(() => {
       test(fixtures('ts-object.vue.d.ts'), expects('ts-object.vue.d.ts'))


### PR DESCRIPTION
As requested, here is the pull request demonstrating the problem when a component contains additional types/interfaces.