### PR TITLE
fix: allow to import other vue files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,12 +14,6 @@
         "@types/node": "9.4.0"
       }
     },
-    "@types/colors": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@types/colors/-/colors-1.1.3.tgz",
-      "integrity": "sha1-VBOwp6GxbdGL4OP9V9L+7Mgcx3Y=",
-      "dev": true
-    },
     "@types/commander": {
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/@types/commander/-/commander-2.12.2.tgz",
@@ -333,7 +327,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
       "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-      "dev": true,
       "requires": {
         "ansi-styles": "3.2.0",
         "escape-string-regexp": "1.0.5",
@@ -344,7 +337,6 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
           "requires": {
             "color-convert": "1.9.1"
           }
@@ -454,7 +446,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -462,13 +453,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "colors": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "commander": {
       "version": "2.13.0",
@@ -735,8 +720,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.9.0",
@@ -1867,8 +1851,7 @@
     "has-flag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-      "dev": true
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
     },
     "has-value": {
       "version": "1.0.0",
@@ -2920,7 +2903,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
       "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-      "dev": true,
       "requires": {
         "has-flag": "2.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -820,8 +820,16 @@
       "requires": {
         "espower-source": "2.2.0",
         "minimatch": "3.0.4",
-        "typescript": "2.6.2",
+        "typescript": "2.7.1",
         "typescript-simple": "8.0.6"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.1.tgz",
+          "integrity": "sha512-bqB1yS6o9TNA9ZC/MJxM0FZzPnZdtHj0xWK/IZ5khzVqdpGul/R/EIiHRgFXlwTD7PSIaYVnGKq1QgMCu2mnqw==",
+          "dev": true
+        }
       }
     },
     "esprima": {
@@ -3100,9 +3108,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q="
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.1.tgz",
+      "integrity": "sha512-bqB1yS6o9TNA9ZC/MJxM0FZzPnZdtHj0xWK/IZ5khzVqdpGul/R/EIiHRgFXlwTD7PSIaYVnGKq1QgMCu2mnqw=="
     },
     "typescript-simple": {
       "version": "8.0.6",
@@ -3110,7 +3118,15 @@
       "integrity": "sha512-BZp2NFHLPTcT/lklpgCDkbPt5CJQE4Lwh9dPzJ01Qsi8FQPdLQJvHCpophpQmaBuVKlxlAeH+AkyNHPdcAFmLA==",
       "dev": true,
       "requires": {
-        "typescript": "2.6.2"
+        "typescript": "2.7.1"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.1.tgz",
+          "integrity": "sha512-bqB1yS6o9TNA9ZC/MJxM0FZzPnZdtHj0xWK/IZ5khzVqdpGul/R/EIiHRgFXlwTD7PSIaYVnGKq1QgMCu2mnqw==",
+          "dev": true
+        }
       }
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "colors": "^1.1.2",
     "commander": "^2.13.0",
     "glob": "^7.1.2",
-    "typescript": "2.6.2",
+    "typescript": "2.7.1",
     "vue-template-compiler": "^2.5.13"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   },
   "devDependencies": {
     "@types/chokidar": "^1.7.4",
-    "@types/colors": "^1.1.3",
     "@types/commander": "^2.12.2",
     "@types/glob": "^5.0.35",
     "@types/memory-fs": "^0.3.0",
@@ -55,8 +54,8 @@
     "vue-class-component": "^6.1.2"
   },
   "dependencies": {
+    "chalk": "^2.3.0",
     "chokidar": "^2.0.0",
-    "colors": "^1.1.2",
     "commander": "^2.13.0",
     "glob": "^7.1.2",
     "typescript": "2.7.1",

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -1,5 +1,3 @@
-import 'colors'
-
 import path = require('path')
 import ts = require('typescript')
 import { LanguageService } from './language-service'

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,15 +1,17 @@
+import chalk from 'chalk'
+
 export function logEmitted (filePath: string): void {
-  console.log('Emitted: '.green + filePath)
+  console.log(chalk.green('Emitted: ') + filePath)
 }
 
 export function logRemoved (filePath: string): void {
-  console.log('Removed: '.green + filePath)
+  console.log(chalk.green('Removed: ') + filePath)
 }
 
 export function logError (filePath: string, messages: string[]): void {
   const errors = [
-    'Emit Failed: '.red + filePath,
-    ...messages.map(m => '  ' + 'Error: '.red + m)
+    chalk.red('Emit Failed: ') + filePath,
+    ...messages.map(m => '  ' + chalk.red('Error: ') + m)
   ]
   console.error(errors.join('\n'))
 }

--- a/test/expects/import-other.vue.d.ts
+++ b/test/expects/import-other.vue.d.ts
@@ -1,0 +1,5 @@
+import Vue, { VueConstructor } from 'vue';
+declare const _default: VueConstructor<{
+    foo: string;
+} & Record<never, any> & Vue>;
+export default _default;

--- a/test/fixtures/import-other-target.vue
+++ b/test/fixtures/import-other-target.vue
@@ -1,0 +1,8 @@
+<template>
+  <p>Hi</p>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+export default Vue.extend({})
+</script>

--- a/test/fixtures/import-other.vue
+++ b/test/fixtures/import-other.vue
@@ -1,0 +1,20 @@
+<template>
+  <Target />
+</template>
+
+<script lang="ts">
+import Vue, { VueConstructor } from 'vue'
+import Target from './import-other-target.vue'
+
+export default Vue.extend({
+  components: {
+    Target
+  },
+
+  data () {
+    return {
+      foo: 'Hello'
+    }
+  }
+})
+</script>

--- a/test/specs/generate.ts
+++ b/test/specs/generate.ts
@@ -68,6 +68,12 @@ describe('generate', () => {
       test(fixtures('src.vue.d.ts'), expects('src.vue.d.ts'))
     })
   })
+
+  it('should be able to import other vue files', () => {
+    return gen(fixtures('import-other.vue'), compilerOptions).then(() => {
+      test(fixtures('import-other.vue.d.ts'), expects('import-other.vue.d.ts'))
+    })
+  })
 })
 
 function normalize (str: string): string {


### PR DESCRIPTION
This PR enables to import `.vue` file from a target `.vue` file which will be generated d.ts file.
It also update TypeScript version to the latest.

Note that the latest TypeScript always set `emitSkipped = false` (I have no idea why), so I changed the strategy to detect errors to simply count error messages.