### PR TITLE
feat: watch derived ts files changes

### DIFF
--- a/src/lib/language-service.ts
+++ b/src/lib/language-service.ts
@@ -24,6 +24,10 @@ export class LanguageService {
     this.files.updateFile(fileName)
   }
 
+  getHostVueFilePaths (fileName: string): string[] {
+    return this.files.getHostVueFilePaths(fileName)
+  }
+
   getDts (fileName: string): Result<string> {
     fileName = normalize(fileName)
 

--- a/src/lib/watch.ts
+++ b/src/lib/watch.ts
@@ -19,18 +19,24 @@ export function watch (
   })
 
   watcher
-    .on('add', onlyVue(file => {
-      service.updateFile(file)
-      saveDts(file, service)
-    }))
-    .on('change', onlyVue(file => {
-      service.updateFile(file)
-      saveDts(file, service)
-    }))
-    .on('unlink', onlyVue(file => {
-      service.updateFile(file)
-      removeDts(file)
-    }))
+    .on('add', rawFile => {
+      service.getHostVueFilePaths(rawFile).forEach(file => {
+        service.updateFile(file)
+        saveDts(file, service)
+      })
+    })
+    .on('change', rawFile => {
+      service.getHostVueFilePaths(rawFile).forEach(file => {
+        service.updateFile(file)
+        saveDts(file, service)
+      })
+    })
+    .on('unlink', rawFile => {
+      service.getHostVueFilePaths(rawFile).forEach(file => {
+        service.updateFile(file)
+        removeDts(file)
+      })
+    })
 
   return watcher
 }
@@ -62,9 +68,3 @@ function removeDts (fileName: string): void {
     )
 }
 
-function onlyVue (fn: (fileName: string) => void): (fileName: string) => void {
-  return fileName => {
-    if (!/\.vue$/.test(fileName)) return
-    fn(fileName)
-  }
-}


### PR DESCRIPTION
This PR makes the watcher also watching the changes of derived `.ts` files via `.vue` files.
The implementation is simply searching the *host* `.vue` files of it if some file is changed. I'm not sure the performance drawback but I think it can be easy to add a hash map in that case.